### PR TITLE
setup.py: use the include directory of numpy as defined by the numpy installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ with open('README.rst', 'r', encoding='utf-8') as readme:
 
 c_ext = Extension('spleaf.libspleaf',
   sources=['spleaf/pywrapspleaf.c', 'spleaf/libspleaf.c'],
+  include_dirs=[numpy.get_include()],
   language='c')
 
 setup(name=info['__title__'],


### PR DESCRIPTION
This allows the spleaf package to be installing using pip on Mac OS X, which I assume has a different location on the numpy include files as the original author's machine.